### PR TITLE
Fixes Cabauw case.

### DIFF
--- a/cases/cabauw/cabauw_input.py
+++ b/cases/cabauw/cabauw_input.py
@@ -41,11 +41,13 @@ def create_case_input(
 
     # Link required files (if not present)
     if use_htessel:
-        mht.copy_lsmfiles(link=linknotcopy)
+        mht.copy_lsmfiles(srcdir='../../misc/', link=linknotcopy)
+
     if use_rrtmgp:
-        mht.copy_radfiles(gpt=gpt_set,link=linknotcopy)
+        mht.copy_radfiles(srcdir='../../rte-rrtmgp-cpp/rrtmgp-data/', gpt=gpt_set, link=linknotcopy)
+
     if use_aerosols:
-        mht.copy_aerosolfiles(link=linknotcopy)
+        mht.copy_aerosolfiles(srcdir='../../rte-rrtmgp-cpp/data/', link=linknotcopy)
 
 
     heterogeneous_sfc = not use_homogeneous_z0 or not use_homogeneous_ls

--- a/python/microhh_tools.py
+++ b/python/microhh_tools.py
@@ -1006,34 +1006,35 @@ def run_restart(
             return 1
     return 0
 
+
 def copy_or_link(src, dst, link = False):
     if os.path.exists(dst):
         if os.path.isfile(dst):
             os.remove(dst)
     if link:
         os.symlink(src, dst)
-        # print("Linking ",end="")
     else:
         shutil.copy(src, dst)
-        # print("Copying ",end="")
-    # print(src," to ",dst)
+
 
 def copy_radfiles(srcdir = None, destdir = None, gpt = '128_112', link = False):
     if srcdir is None:
         srcdir = os.path.dirname(inspect.getabsfile(inspect.currentframe()))+'/../rte-rrtmgp-cpp/rrtmgp-data/' 
     if destdir is None:
         destdir = os.getcwd()
+
     if gpt == '128_112':
-        copy_or_link(srcdir + 'rrtmgp-gas-lw-g128.nc', destdir + '/coefficients_lw.nc', link = link)
-        copy_or_link(srcdir + 'rrtmgp-gas-sw-g112.nc', destdir + '/coefficients_sw.nc', link = link)
+        copy_or_link(os.path.join(srcdir, 'rrtmgp-gas-lw-g128.nc'), os.path.join(destdir, 'coefficients_lw.nc'), link = link)
+        copy_or_link(os.path.join(srcdir, 'rrtmgp-gas-sw-g112.nc'), os.path.join(destdir, 'coefficients_sw.nc'), link = link)
     elif gpt == '256_224':
-        copy_or_link(srcdir + 'rrtmgp-gas-lw-g256.nc', destdir + '/coefficients_lw.nc', link = link)
-        copy_or_link(srcdir + 'rrtmgp-gas-sw-g224.nc', destdir + '/coefficients_sw.nc', link = link)
+        copy_or_link(os.path.join(srcdir, 'rrtmgp-gas-lw-g256.nc'), os.path.join(destdir, 'coefficients_lw.nc'), link = link)
+        copy_or_link(os.path.join(srcdir, 'rrtmgp-gas-sw-g224.nc'), os.path.join(destdir, 'coefficients_sw.nc'), link = link)
     else:
         raise ValueError('gpt should be in {\'128_112\', \'256_224\'}')
 
-    copy_or_link(srcdir + 'rrtmgp-clouds-lw.nc', destdir + '/cloud_coefficients_lw.nc', link = link)
-    copy_or_link(srcdir + 'rrtmgp-clouds-sw.nc', destdir + '/cloud_coefficients_sw.nc', link = link)
+    copy_or_link(os.path.join(srcdir, 'rrtmgp-clouds-lw.nc'), os.path.join(destdir, 'cloud_coefficients_lw.nc'), link = link)
+    copy_or_link(os.path.join(srcdir, 'rrtmgp-clouds-sw.nc'), os.path.join(destdir, 'cloud_coefficients_sw.nc'), link = link)
+
 
 def copy_aerosolfiles(srcdir = None, destdir = None, link = False):
     if srcdir is None:
@@ -1041,12 +1042,14 @@ def copy_aerosolfiles(srcdir = None, destdir = None, link = False):
     if destdir is None:
         destdir = os.getcwd()
 
-    copy_or_link(srcdir + 'aerosol_optics.nc', destdir + 'aerosol_optics.nc', link = link)
+    copy_or_link(os.path.join(srcdir, 'aerosol_optics.nc'), os.path.join(destdir, 'aerosol_optics.nc'), link = link)
+
 
 def copy_lsmfiles(srcdir = None, destdir = None, link = False):
     if srcdir is None:
         srcdir = os.path.dirname(inspect.getabsfile(inspect.currentframe()))+'/../misc/'
     if destdir is None:
         destdir = os.getcwd()
-    copy_or_link(srcdir+'van_genuchten_parameters.nc', destdir, link = link)
+
+    copy_or_link(os.path.join(srcdir, 'van_genuchten_parameters.nc'), destdir, link = link)
     


### PR DESCRIPTION
- The automatic linking of the land-surface/radiation NetCDFs only worked if `microhh/python` was added to the Python path, not if you e.g. link `microhh_tools.py` to the Cabauw case directory. Fixed by explicitly specifying the relative paths.
- Linking/copying of the aerosol NetCDF failed, because a `/` was missing. Using `os.path.join()` is a safer method.